### PR TITLE
Changed functions

### DIFF
--- a/keyboards/gmmk/gmmk2/p65/ansi/keymaps/skelvir/keymap.c
+++ b/keyboards/gmmk/gmmk2/p65/ansi/keymaps/skelvir/keymap.c
@@ -26,14 +26,19 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  * Ü mapped to AltGr+Shift+U or AltGr+Shift+Y
  * ü mapped to AltGr+u or AltGr+y
  * ß mapped to AltGr+s
+ * € mapped to AltGr+E
  * Shift+Backspace mapped to Delete, therefore Ctrl+Shift+Backspace deletes the next word (=Ctrl+Delete)
+ * ² mapped to AltGr+2
+ * ³ mapped to AltGr+3
+ * µ mapped to AltGr+m
+ * ø mapped to AltGr+L
+ * ± mapped to AltGr+'='
  *
  *
  * For bootmode hold ESC pressed while plugging in keyboard or Fn+Space, Default Space+B might not work anymore
  *
  *
  */
-
 
 #include QMK_KEYBOARD_H
 
@@ -42,6 +47,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define MODS_SHIFT_MASK (MOD_BIT(KC_LSHIFT)|MOD_BIT(KC_RSHIFT))
 
+/* custom keycodes example
 enum custom_keycodes {
   DE_AE_OnA = SAFE_RANGE, // use the safe range, otherwise other keys may be overriden unintentionally
   DE_AE_OnQ,
@@ -50,15 +56,15 @@ enum custom_keycodes {
   DE_UE_OnU,
   DE_UE_OnY,
   DE_SS_OnS,
-};
+};*/
 
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 // base layer
 [0] = LAYOUT(
   KC_GESC,  KC_1,     KC_2,     KC_3,     KC_4,     KC_5,     KC_6,     KC_7,     KC_8,     KC_9,     KC_0,     KC_MINS,  KC_EQL,   KC_BSPC,  KC_DEL,
-  KC_TAB,   DE_AE_OnQ,     KC_W,     KC_E,     KC_R,     KC_T,     DE_UE_OnY,     DE_UE_OnU,     KC_I,     DE_OE_OnO,     DE_OE_OnP,     KC_LBRC,  KC_RBRC,  KC_BSLS,   KC_PGUP,
-  MO(1),  DE_AE_OnA,     DE_SS_OnS,     KC_D,     KC_F,     KC_G,     KC_H,     KC_J,     KC_K,     KC_L,     KC_SCLN,  KC_QUOT,  KC_ENT,            KC_PGDN,
+  KC_TAB,   KC_Q,     KC_W,     KC_E,     KC_R,     KC_T,     KC_Y,     KC_U,     KC_I,     KC_O,     KC_P,     KC_LBRC,  KC_RBRC,  KC_BSLS,   KC_PGUP,
+  MO(1),  KC_A,     KC_S,     KC_D,     KC_F,     KC_G,     KC_H,     KC_J,     KC_K,     KC_L,     KC_SCLN,  KC_QUOT,  KC_ENT,            KC_PGDN,
   KC_LSFT,  KC_Z,     KC_X,     KC_C,     KC_V,     KC_B,     KC_N,     KC_M,     KC_COMM,  KC_DOT,   KC_SLSH,  KC_RSFT,  KC_UP,    KC_END,
   KC_LCTL,  KC_LGUI,  KC_LALT,                                KC_SPC,                                 KC_RALT,  MO(1),    KC_LEFT,  KC_DOWN,  KC_RGHT),
 // function layer
@@ -89,8 +95,155 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record)
 {
   switch(keycode) 
   {
+
+    // ± 241
+    case KC_EQL:
+      if (record->event.pressed) {
+        uint8_t temp_mod = get_mods();
+
+        if(temp_mod & MOD_BIT(KC_RALT))
+        {
+          clear_mods();
+          register_code(KC_LALT);
+          tap_key(KC_P2); tap_key(KC_P4); tap_key(KC_P1); // ±
+          unregister_code(KC_LALT);
+          set_mods(temp_mod);
+          unregister_code(KC_RALT); // unregister AltGr to prevent window menu selecting
+          return false; // Skip further key processing 
+        }
+        else
+        {
+          return true; // let QMK handle = normally
+        }
+        
+        
+      }
+      break;
+
+    // ø 0248
+    case KC_L:
+      if (record->event.pressed) {
+        uint8_t temp_mod = get_mods();
+
+        if(temp_mod & MOD_BIT(KC_RALT))
+        {
+          clear_mods();
+          register_code(KC_LALT);
+          tap_key(KC_P0); tap_key(KC_P2); tap_key(KC_P4); tap_key(KC_P8); // ø
+          unregister_code(KC_LALT);
+          set_mods(temp_mod);
+          unregister_code(KC_RALT); // unregister AltGr to prevent window menu selecting
+          return false; // Skip further key processing 
+        }
+        else
+        {
+          return true; // let QMK handle 2 normally
+        }
+        
+        
+      }
+      break;
+
+    // µ 0181
+    case KC_M:
+      if (record->event.pressed) {
+        uint8_t temp_mod = get_mods();
+
+        if(temp_mod & MOD_BIT(KC_RALT))
+        {
+          clear_mods();
+          register_code(KC_LALT);
+          tap_key(KC_P0); tap_key(KC_P1); tap_key(KC_P8); tap_key(KC_P1); // µ
+          unregister_code(KC_LALT);
+          set_mods(temp_mod);
+          unregister_code(KC_RALT); // unregister AltGr to prevent window menu selecting
+          return false; // Skip further key processing 
+        }
+        else
+        {
+          return true; // let QMK handle 2 normally
+        }
+        
+        
+      }
+      break;
+
+    // sqr2 0178
+    case KC_2:
+      if (record->event.pressed) {
+        uint8_t temp_mod = get_mods();
+
+        if(temp_mod & MOD_BIT(KC_RALT))
+        {
+          clear_mods();
+          register_code(KC_LALT);
+          tap_key(KC_P0); tap_key(KC_P1); tap_key(KC_P7); tap_key(KC_P8); // ²
+          unregister_code(KC_LALT);
+          set_mods(temp_mod);
+          unregister_code(KC_RALT); // unregister AltGr to prevent window menu selecting
+          return false; // Skip further key processing 
+        }
+        else
+        {
+          return true; // let QMK handle 2 normally
+        }
+        
+        
+      }
+      break;
+
+    // sqr3 0179
+    case KC_3:
+      if (record->event.pressed) {
+        uint8_t temp_mod = get_mods();
+
+        if(temp_mod & MOD_BIT(KC_RALT))
+        {
+          clear_mods();
+          register_code(KC_LALT);
+          tap_key(KC_P0); tap_key(KC_P1); tap_key(KC_P7); tap_key(KC_P9); // ³
+          unregister_code(KC_LALT);
+          set_mods(temp_mod);
+          unregister_code(KC_RALT); // unregister AltGr to prevent window menu selecting
+          return false; // Skip further key processing 
+        }
+        else
+        {
+          return true; // let QMK handle 2 normally
+        }
+        
+        
+      }
+      break;
+
+
+    // € 0128
+    case KC_E:
+      if (record->event.pressed) {
+        uint8_t temp_mod = get_mods();
+
+        if(temp_mod & MOD_BIT(KC_RALT))
+        {
+          clear_mods();
+          register_code(KC_LALT);
+          tap_key(KC_P0); tap_key(KC_P1); tap_key(KC_P2); tap_key(KC_P8); // €
+          unregister_code(KC_LALT);
+          set_mods(temp_mod);
+          unregister_code(KC_RALT); // unregister AltGr to prevent window menu selecting
+          return false; // Skip further key processing 
+        }
+        else
+        {
+          return true; // let QMK handle E normally
+        }
+        
+        
+      }
+      break;
+
+
     // Ä 142, ä 132
-    case DE_AE_OnA:
+    case KC_A:
       if (record->event.pressed) {
         uint8_t temp_mod = get_mods();
 
@@ -105,10 +258,11 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record)
           }
           unregister_code(KC_LALT);
           set_mods(temp_mod);
+          unregister_code(KC_RALT); // unregister AltGr to prevent window menu selecting
         }
         else
         {
-          tap_key(KC_A); // default processing A
+          return true; // default processing A
         }
         return false; // Skip further key processing
         
@@ -116,7 +270,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record)
       }
       break;
 
-    case DE_AE_OnQ:
+    case KC_Q:
       if (record->event.pressed) {
         uint8_t temp_mod = get_mods();
 
@@ -131,10 +285,11 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record)
           }
           unregister_code(KC_LALT);
           set_mods(temp_mod);
+          unregister_code(KC_RALT); // unregister AltGr to prevent window menu selecting
         }
         else
         {
-          tap_key(KC_Q); // default processing Q
+          return true; // default processing Q
         }
         return false; // Skip further key processing
         
@@ -143,7 +298,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record)
       break;
 
     // Ö 153, ö 148
-    case DE_OE_OnO:
+    case KC_O:
       if (record->event.pressed) {
         uint8_t temp_mod = get_mods();
 
@@ -158,10 +313,11 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record)
           }
           unregister_code(KC_LALT);
           set_mods(temp_mod);
+          unregister_code(KC_RALT); // unregister AltGr to prevent window menu selecting
         }
         else
         {
-          tap_key(KC_O); // default processing O
+          return true; // default processing O
         }
 
         return false; // Skip further key processing
@@ -170,7 +326,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record)
       }
       break;
 
-    case DE_OE_OnP:
+    case KC_P:
       if (record->event.pressed) {
         uint8_t temp_mod = get_mods();
 
@@ -185,10 +341,11 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record)
           }
           unregister_code(KC_LALT);
           set_mods(temp_mod);
+          unregister_code(KC_RALT); // unregister AltGr to prevent window menu selecting
         }
         else
         {
-          tap_key(KC_P); // default processing P
+          return true; // default processing P
         }
 
         return false; // Skip further key processing
@@ -199,7 +356,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record)
 
 
     // Ü 154, ü 129
-    case DE_UE_OnU:
+    case KC_U:
       if (record->event.pressed) {
         uint8_t temp_mod = get_mods();
 
@@ -214,10 +371,11 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record)
           }
           unregister_code(KC_LALT);
           set_mods(temp_mod);
+          unregister_code(KC_RALT); // unregister AltGr to prevent window menu selecting
         }
         else
         {
-          tap_key(KC_U); // default processing U
+          return true; // default processing U
         }
 
         return false; // Skip further key processing
@@ -226,7 +384,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record)
       }
       break;
 
-    case DE_UE_OnY:
+    case KC_Y:
       if (record->event.pressed) {
         uint8_t temp_mod = get_mods();
 
@@ -241,10 +399,11 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record)
           }
           unregister_code(KC_LALT);
           set_mods(temp_mod);
+          unregister_code(KC_RALT); // unregister AltGr to prevent window menu selecting
         }
         else
         {
-          tap_key(KC_Y); // default processing Y
+          return true; // default processing Y
         }
 
         return false; // Skip further key processing
@@ -256,7 +415,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record)
 
 
     // ß 225
-    case DE_SS_OnS:
+    case KC_S:
       if (record->event.pressed) {
         uint8_t temp_mod = get_mods();
 
@@ -267,10 +426,11 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record)
           tap_key(KC_P2); tap_key(KC_P2); tap_key(KC_P5); // ß
           unregister_code(KC_LALT);
           set_mods(temp_mod);
+          unregister_code(KC_RALT); // unregister AltGr to prevent window menu selecting
         }
         else
         {
-          tap_key(KC_S); // default processing S
+          return true; // default processing S
         }
 
         return false; // Skip further key processing

--- a/keyboards/gmmk/gmmk2/p96/ansi/keymaps/skelvir/keymap.c
+++ b/keyboards/gmmk/gmmk2/p96/ansi/keymaps/skelvir/keymap.c
@@ -26,7 +26,13 @@
  * Ü mapped to AltGr+Shift+U or AltGr+Shift+Y
  * ü mapped to AltGr+u or AltGr+y
  * ß mapped to AltGr+s
+ * € mapped to AltGr+E
  * Shift+Backspace mapped to Delete, therefore Ctrl+Shift+Backspace deletes the next word (=Ctrl+Delete)
+ * ² mapped to AltGr+2
+ * ³ mapped to AltGr+3
+ * µ mapped to AltGr+m
+ * ø mapped to AltGr+L
+ * ± mapped to AltGr+'='
  *
  *
  * For bootmode hold ESC pressed while plugging in keyboard or Fn+Space, Default Space+B might not work anymore
@@ -43,6 +49,7 @@
 
 #define MODS_SHIFT_MASK (MOD_BIT(KC_LSHIFT)|MOD_BIT(KC_RSHIFT))
 
+/* custom keycodes example
 enum custom_keycodes {
   DE_AE_OnA = SAFE_RANGE, // use the safe range, otherwise other keys may be overriden unintentionally
   DE_AE_OnQ,
@@ -51,7 +58,7 @@ enum custom_keycodes {
   DE_UE_OnU,
   DE_UE_OnY,
   DE_SS_OnS,
-};
+};*/
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   /* Keymap _BL: Base Layer (Default Layer)
@@ -59,8 +66,8 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 [_BL] = LAYOUT(
   KC_GESC,  KC_F1,    KC_F2,    KC_F3,    KC_F4,    KC_F5,    KC_F6,    KC_F7,    KC_F8,    KC_F9,    KC_F10,   KC_F11,   KC_F12,   KC_PSCR,  KC_DEL,   KC_INS,   KC_PGUP,  KC_PGDN,
   KC_GRV,   KC_1,     KC_2,     KC_3,     KC_4,     KC_5,     KC_6,     KC_7,     KC_8,     KC_9,     KC_0,     KC_MINS,  KC_EQL,   KC_BSPC,  KC_NLCK,  KC_PSLS,  KC_PAST,  KC_PMNS,
-  KC_TAB,   DE_AE_OnQ,     KC_W,     KC_E,     KC_R,     KC_T,     DE_UE_OnY,     DE_UE_OnU,     KC_I,     DE_OE_OnO,     DE_OE_OnP,     KC_LBRC,  KC_RBRC,  KC_BSLS,   KC_P7,    KC_P8,    KC_P9,    KC_PPLS,
-  MO(_FL),  DE_AE_OnA,     DE_SS_OnS,     KC_D,     KC_F,     KC_G,     KC_H,     KC_J,     KC_K,     KC_L,     KC_SCLN,  KC_QUOT,              KC_ENT,   KC_P4,    KC_P5,    KC_P6,
+  KC_TAB,   KC_Q,     KC_W,     KC_E,     KC_R,     KC_T,     KC_Y,     KC_U,     KC_I,     KC_O,     KC_P,     KC_LBRC,  KC_RBRC,  KC_BSLS,   KC_P7,    KC_P8,    KC_P9,    KC_PPLS,
+  MO(_FL),  KC_A,     KC_S,     KC_D,     KC_F,     KC_G,     KC_H,     KC_J,     KC_K,     KC_L,     KC_SCLN,  KC_QUOT,              KC_ENT,   KC_P4,    KC_P5,    KC_P6,
   KC_LSFT,  KC_Z,     KC_X,     KC_C,     KC_V,     KC_B,     KC_N,     KC_M,     KC_COMM,  KC_DOT,   KC_SLSH,  KC_RSFT,  KC_UP,    KC_P1,    KC_P2,    KC_P3,    KC_PENT,
   KC_LCTL,  KC_LGUI,  KC_LALT,                      KC_SPC,                                 KC_RALT,  MO(_FL),  KC_RCTL,  KC_LEFT,  KC_DOWN,  KC_RGHT,  KC_P0,    KC_PDOT),
 
@@ -84,8 +91,155 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record)
 {
   switch(keycode) 
   {
+
+    // ± 241
+    case KC_EQL:
+      if (record->event.pressed) {
+        uint8_t temp_mod = get_mods();
+
+        if(temp_mod & MOD_BIT(KC_RALT))
+        {
+          clear_mods();
+          register_code(KC_LALT);
+          tap_key(KC_P2); tap_key(KC_P4); tap_key(KC_P1); // ±
+          unregister_code(KC_LALT);
+          set_mods(temp_mod);
+          unregister_code(KC_RALT); // unregister AltGr to prevent window menu selecting
+          return false; // Skip further key processing 
+        }
+        else
+        {
+          return true; // let QMK handle = normally
+        }
+        
+        
+      }
+      break;
+
+    // ø 0248
+    case KC_L:
+      if (record->event.pressed) {
+        uint8_t temp_mod = get_mods();
+
+        if(temp_mod & MOD_BIT(KC_RALT))
+        {
+          clear_mods();
+          register_code(KC_LALT);
+          tap_key(KC_P0); tap_key(KC_P2); tap_key(KC_P4); tap_key(KC_P8); // ø
+          unregister_code(KC_LALT);
+          set_mods(temp_mod);
+          unregister_code(KC_RALT); // unregister AltGr to prevent window menu selecting
+          return false; // Skip further key processing 
+        }
+        else
+        {
+          return true; // let QMK handle 2 normally
+        }
+        
+        
+      }
+      break;
+
+    // µ 0181
+    case KC_M:
+      if (record->event.pressed) {
+        uint8_t temp_mod = get_mods();
+
+        if(temp_mod & MOD_BIT(KC_RALT))
+        {
+          clear_mods();
+          register_code(KC_LALT);
+          tap_key(KC_P0); tap_key(KC_P1); tap_key(KC_P8); tap_key(KC_P1); // µ
+          unregister_code(KC_LALT);
+          set_mods(temp_mod);
+          unregister_code(KC_RALT); // unregister AltGr to prevent window menu selecting
+          return false; // Skip further key processing 
+        }
+        else
+        {
+          return true; // let QMK handle 2 normally
+        }
+        
+        
+      }
+      break;
+
+    // sqr2 0178
+    case KC_2:
+      if (record->event.pressed) {
+        uint8_t temp_mod = get_mods();
+
+        if(temp_mod & MOD_BIT(KC_RALT))
+        {
+          clear_mods();
+          register_code(KC_LALT);
+          tap_key(KC_P0); tap_key(KC_P1); tap_key(KC_P7); tap_key(KC_P8); // ²
+          unregister_code(KC_LALT);
+          set_mods(temp_mod);
+          unregister_code(KC_RALT); // unregister AltGr to prevent window menu selecting
+          return false; // Skip further key processing 
+        }
+        else
+        {
+          return true; // let QMK handle 2 normally
+        }
+        
+        
+      }
+      break;
+
+    // sqr3 0179
+    case KC_3:
+      if (record->event.pressed) {
+        uint8_t temp_mod = get_mods();
+
+        if(temp_mod & MOD_BIT(KC_RALT))
+        {
+          clear_mods();
+          register_code(KC_LALT);
+          tap_key(KC_P0); tap_key(KC_P1); tap_key(KC_P7); tap_key(KC_P9); // ³
+          unregister_code(KC_LALT);
+          set_mods(temp_mod);
+          unregister_code(KC_RALT); // unregister AltGr to prevent window menu selecting
+          return false; // Skip further key processing 
+        }
+        else
+        {
+          return true; // let QMK handle 2 normally
+        }
+        
+        
+      }
+      break;
+
+
+    // € 0128
+    case KC_E:
+      if (record->event.pressed) {
+        uint8_t temp_mod = get_mods();
+
+        if(temp_mod & MOD_BIT(KC_RALT))
+        {
+          clear_mods();
+          register_code(KC_LALT);
+          tap_key(KC_P0); tap_key(KC_P1); tap_key(KC_P2); tap_key(KC_P8); // €
+          unregister_code(KC_LALT);
+          set_mods(temp_mod);
+          unregister_code(KC_RALT); // unregister AltGr to prevent window menu selecting
+          return false; // Skip further key processing 
+        }
+        else
+        {
+          return true; // let QMK handle E normally
+        }
+        
+        
+      }
+      break;
+
+
     // Ä 142, ä 132
-    case DE_AE_OnA:
+    case KC_A:
       if (record->event.pressed) {
         uint8_t temp_mod = get_mods();
 
@@ -100,10 +254,11 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record)
           }
           unregister_code(KC_LALT);
           set_mods(temp_mod);
+          unregister_code(KC_RALT); // unregister AltGr to prevent window menu selecting
         }
         else
         {
-          tap_key(KC_A); // default processing A
+          return true; // default processing A
         }
         return false; // Skip further key processing
         
@@ -111,7 +266,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record)
       }
       break;
 
-    case DE_AE_OnQ:
+    case KC_Q:
       if (record->event.pressed) {
         uint8_t temp_mod = get_mods();
 
@@ -126,10 +281,11 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record)
           }
           unregister_code(KC_LALT);
           set_mods(temp_mod);
+          unregister_code(KC_RALT); // unregister AltGr to prevent window menu selecting
         }
         else
         {
-          tap_key(KC_Q); // default processing Q
+          return true; // default processing Q
         }
         return false; // Skip further key processing
         
@@ -138,7 +294,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record)
       break;
 
     // Ö 153, ö 148
-    case DE_OE_OnO:
+    case KC_O:
       if (record->event.pressed) {
         uint8_t temp_mod = get_mods();
 
@@ -153,10 +309,11 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record)
           }
           unregister_code(KC_LALT);
           set_mods(temp_mod);
+          unregister_code(KC_RALT); // unregister AltGr to prevent window menu selecting
         }
         else
         {
-          tap_key(KC_O); // default processing O
+          return true; // default processing O
         }
 
         return false; // Skip further key processing
@@ -165,7 +322,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record)
       }
       break;
 
-    case DE_OE_OnP:
+    case KC_P:
       if (record->event.pressed) {
         uint8_t temp_mod = get_mods();
 
@@ -180,10 +337,11 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record)
           }
           unregister_code(KC_LALT);
           set_mods(temp_mod);
+          unregister_code(KC_RALT); // unregister AltGr to prevent window menu selecting
         }
         else
         {
-          tap_key(KC_P); // default processing P
+          return true; // default processing P
         }
 
         return false; // Skip further key processing
@@ -194,7 +352,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record)
 
 
     // Ü 154, ü 129
-    case DE_UE_OnU:
+    case KC_U:
       if (record->event.pressed) {
         uint8_t temp_mod = get_mods();
 
@@ -209,10 +367,11 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record)
           }
           unregister_code(KC_LALT);
           set_mods(temp_mod);
+          unregister_code(KC_RALT); // unregister AltGr to prevent window menu selecting
         }
         else
         {
-          tap_key(KC_U); // default processing U
+          return true; // default processing U
         }
 
         return false; // Skip further key processing
@@ -221,7 +380,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record)
       }
       break;
 
-    case DE_UE_OnY:
+    case KC_Y:
       if (record->event.pressed) {
         uint8_t temp_mod = get_mods();
 
@@ -236,10 +395,11 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record)
           }
           unregister_code(KC_LALT);
           set_mods(temp_mod);
+          unregister_code(KC_RALT); // unregister AltGr to prevent window menu selecting
         }
         else
         {
-          tap_key(KC_Y); // default processing Y
+          return true; // default processing Y
         }
 
         return false; // Skip further key processing
@@ -251,7 +411,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record)
 
 
     // ß 225
-    case DE_SS_OnS:
+    case KC_S:
       if (record->event.pressed) {
         uint8_t temp_mod = get_mods();
 
@@ -262,10 +422,11 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record)
           tap_key(KC_P2); tap_key(KC_P2); tap_key(KC_P5); // ß
           unregister_code(KC_LALT);
           set_mods(temp_mod);
+          unregister_code(KC_RALT); // unregister AltGr to prevent window menu selecting
         }
         else
         {
-          tap_key(KC_S); // default processing S
+          return true; // default processing S
         }
 
         return false; // Skip further key processing

--- a/readme.md
+++ b/readme.md
@@ -1,40 +1,4 @@
-# This is the `develop` branch!
+# This is the custom `develop` branch!
 
-See the [Breaking Changes](https://docs.qmk.fm/#/breaking_changes) document for more information.
 
-# Quantum Mechanical Keyboard Firmware
 
-[![Current Version](https://img.shields.io/github/tag/qmk/qmk_firmware.svg)](https://github.com/qmk/qmk_firmware/tags)
-[![Discord](https://img.shields.io/discord/440868230475677696.svg)](https://discord.gg/Uq7gcHh)
-[![Docs Status](https://img.shields.io/badge/docs-ready-orange.svg)](https://docs.qmk.fm)
-[![GitHub contributors](https://img.shields.io/github/contributors/qmk/qmk_firmware.svg)](https://github.com/qmk/qmk_firmware/pulse/monthly)
-[![GitHub forks](https://img.shields.io/github/forks/qmk/qmk_firmware.svg?style=social&label=Fork)](https://github.com/qmk/qmk_firmware/)
-
-This is a keyboard firmware based on the [tmk\_keyboard firmware](https://github.com/tmk/tmk_keyboard) with some useful features for Atmel AVR and ARM controllers, and more specifically, the [OLKB product line](https://olkb.com), the [ErgoDox EZ](https://ergodox-ez.com) keyboard, and the [Clueboard product line](https://clueboard.co).
-
-## Documentation
-
-* [See the official documentation on docs.qmk.fm](https://docs.qmk.fm)
-
-The docs are powered by [Docsify](https://docsify.js.org/) and hosted on [GitHub](/docs/). They are also viewable offline; see [Previewing the Documentation](https://docs.qmk.fm/#/contributing?id=previewing-the-documentation) for more details.
-
-You can request changes by making a fork and opening a [pull request](https://github.com/qmk/qmk_firmware/pulls), or by clicking the "Edit this page" link at the bottom of any page.
-
-## Supported Keyboards
-
-* [Planck](/keyboards/planck/)
-* [Preonic](/keyboards/preonic/)
-* [ErgoDox EZ](/keyboards/ergodox_ez/)
-* [Clueboard](/keyboards/clueboard/)
-* [Cluepad](/keyboards/clueboard/17/)
-* [Atreus](/keyboards/atreus/)
-
-The project also includes community support for [lots of other keyboards](/keyboards/).
-
-## Maintainers
-
-QMK is developed and maintained by Jack Humbert of OLKB with contributions from the community, and of course, [Hasu](https://github.com/tmk). The OLKB product firmwares are maintained by [Jack Humbert](https://github.com/jackhumbert), the Ergodox EZ by [ZSA Technology Labs](https://github.com/zsa), the Clueboard by [Zach White](https://github.com/skullydazed), and the Atreus by [Phil Hagelberg](https://github.com/technomancy).
-
-## Official Website
-
-[qmk.fm](https://qmk.fm) is the official website of QMK, where you can find links to this page, the documentation, and the keyboards supported by QMK.


### PR DESCRIPTION
 /* Custom Layout Skelvir 230226
 * In Windwos, select US default Layout
 * Second Fn Key mapped to Capslock
 * Capslock mapped to Fn + LShift
 * Supporting german Umlaute without the need to use US-INTL keyboard layout:
 * Ä mapped to AltGr+Shift+A or AltGr+Shift+Q
 * ä mapped to AltGr+a or AltGr+q
 * Ö mapped to AltGr+Shift+O or AltGr+Shift+P
 * ö mapped to AltGr+o or AltGr+p
 * Ü mapped to AltGr+Shift+U or AltGr+Shift+Y
 * ü mapped to AltGr+u or AltGr+y
 * ß mapped to AltGr+s
 * € mapped to AltGr+E
 * Shift+Backspace mapped to Delete, therefore Ctrl+Shift+Backspace deletes the next word (=Ctrl+Delete)
 * ² mapped to AltGr+2
 * ³ mapped to AltGr+3
 * µ mapped to AltGr+m
 * ø mapped to AltGr+L
 * ± mapped to AltGr+'='
 *
 *
 * For bootmode hold ESC pressed while plugging in keyboard or Fn+Space, Default Space+B might not work anymore
 *
 *
 */